### PR TITLE
Data.Map used instead of pairs in Generator.hs

### DIFF
--- a/LaTeX-generator.cabal
+++ b/LaTeX-generator.cabal
@@ -67,7 +67,8 @@ executable texgen
                        text >=1.2.3.1,
                        megaparsec >= 9.0.1,
                        mtl        >= 2.2.2,
-                       exceptions >= 0.10.4
+                       exceptions >= 0.10.4,
+                       containers >= 0.4.0.0
                        
 
   -- Directories containing source files.

--- a/src/Generator.hs
+++ b/src/Generator.hs
@@ -295,6 +295,7 @@ pPrefLineEnvironment defs@Definitions{prefs} = do
     els   <- pEl `sepBy` try pPref
     return $ DocPrefGroup pref els
 
+-- TODO its not uses defs
 pParagraph :: Definitions -> Parser DocElement
 pParagraph defs = do
     ind <- indentLevel

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -3,6 +3,9 @@ import Data.Maybe (mapMaybe, maybeToList)
 import Control.Applicative (Alternative ((<|>), many))
 import Control.Monad.Fail (MonadFail)
 import Control.Monad.Except (MonadError (throwError, catchError))
+import qualified Data.Map.Merge.Strict as M
+import qualified Data.Map.Strict as M
+
 
 (.:) :: Functor f => (b -> c) -> (a -> f b) -> a -> f c
 f .: g = fmap f . g
@@ -48,3 +51,10 @@ sepBy1_ p sep = (:) <$> p <*> (
 
 withError :: MonadError e m => (e -> e) -> m a -> m a
 withError f ma = catchError ma (throwError . f)
+
+-- | unite Maps with side effects
+unionWithA :: (Ord k, Applicative m) => (a -> a -> m a) -> M.Map k a -> M.Map k a -> m (M.Map k a)
+unionWithA g = M.mergeA hMiss hMiss hMatched
+    where
+        hMiss       = M.mapMissing $ const id
+        hMatched    = M.zipWithAMatched $ const g


### PR DESCRIPTION
Definition refactored with Map instead of pairs. Code adopted to this. No features of Map not used yet.